### PR TITLE
fix emit-code method

### DIFF
--- a/src/backend.lisp
+++ b/src/backend.lisp
@@ -74,7 +74,7 @@ Copyright (c) 2014 κeen
   (declare (ignore output-p))
   (let ((sym (varsym obj)))
     (unless (find-from-scope sym backend)
-      (push sym (symbols backend)))
+      (pushnew sym (symbols backend)))
     sym))
 
 (defmethod http-escape ((obj att-variable) sexp)


### PR DESCRIPTION
`(render "{{var name}}{{var name}}" :name "name")`  
でlambda-listにnameが重複してエラーになっていました
